### PR TITLE
fix: 修复 GitHub Actions 输出格式问题

### DIFF
--- a/.github/workflows/issue-chat.yml
+++ b/.github/workflows/issue-chat.yml
@@ -50,7 +50,10 @@ jobs:
           TITLE=$(gh issue view "$ISSUE_NUMBER" --json title --jq '.title')
           BODY=$(gh issue view "$ISSUE_NUMBER" --json body --jq '.body')
           echo "title=$TITLE" >> $GITHUB_OUTPUT
-          echo "body=$BODY" >> $GITHUB_OUTPUT
+          # 使用 heredoc 安全地处理多行内容和特殊字符
+          echo "body<<BODYEOF" >> $GITHUB_OUTPUT
+          echo "$BODY" >> $GITHUB_OUTPUT
+          echo "BODYEOF" >> $GITHUB_OUTPUT
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 


### PR DESCRIPTION
## 问题

当 issue body 包含以 `-` 开头的文本时，工作流会失败并报错：

```
##[error]Unable to process file command 'output' successfully.
##[error]Invalid format '- 两个智能体结合文献进行对话'
```

## 原因

GitHub Actions 的 `$GITHUB_OUTPUT` 文件格式对特殊字符敏感。当使用 `echo "body=$BODY" >> $GITHUB_OUTPUT` 直接输出包含 `-` 开头的多行文本时，会被解析器误认为格式标记。

## 解决方案

使用 heredoc 语法安全地处理多行内容和特殊字符：

```yaml
echo "body<<BODYEOF" >> $GITHUB_OUTPUT
echo "$BODY" >> $GITHUB_OUTPUT
echo "BODYEOF" >> $GITHUB_OUTPUT
```

## 测试

- ✅ 测试包含 `-` 开头文本的 issue（如 issue #47）
- ✅ 测试普通 issue
- ✅ Pre-commit 检查全部通过

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>